### PR TITLE
[CAP-22] Added rate limit exception handling and tests for NotamFetcher (in the case of the exception)

### DIFF
--- a/notam_fetcher/exceptions.py
+++ b/notam_fetcher/exceptions.py
@@ -3,7 +3,7 @@ class NotamFetcherBaseError(Exception):
     """Base exception for NotamFetcher errors."""
 
 class NotamFetcherUnexpectedError(NotamFetcherBaseError):
-    """Raised when an unexpected error occurs which violates assumptions about the API's behavior."""
+    """Raised when an unexpected error occurs"""
 
 class NotamFetcherRequestError(NotamFetcherBaseError):
     """Raised when NotamFetcher receives a request exception while fetching from the API"""
@@ -18,3 +18,10 @@ class NotamFetcherValidationError(NotamFetcherBaseError):
     def __init__(self, message: str, obj: Any):
         super().__init__(message)
         self.invalid_object = obj
+
+class NotamFetcherRateLimitError(NotamFetcherBaseError):
+    """The FAA API applies rate limiting on a rolling basis, meaning the limit (30 requests per minute) is not strictly measured from the time we send our first request.
+        Instead, the API likely tracks requests based on its own internal clock, so you might sometimes be able to make more than 30 requests before hitting the limit."""
+
+    def __init__(self):
+        message = "Rate limit exceeded. Try again later."

--- a/notam_fetcher/notam_fetcher.py
+++ b/notam_fetcher/notam_fetcher.py
@@ -9,6 +9,7 @@ from .exceptions import (
     NotamFetcherUnauthenticatedError,
     NotamFetcherUnexpectedError,
     NotamFetcherValidationError,
+    NotamFetcherRateLimitError
 )
 
 
@@ -251,9 +252,14 @@ class NotamFetcher:
                 },
                 params=query_string,
             )
+
         except requests.exceptions.RequestException as e:
             raise NotamFetcherRequestError from e
 
+        # Check for a rate limit response
+        if response.status_code == 429:
+        # Assuming you have imported NotamFetcherRateLimitError from your exceptions module
+            raise NotamFetcherRateLimitError()        
         try:
             return response.json()
         except requests.exceptions.JSONDecodeError as e:


### PR DESCRIPTION
A few things to note on this ticket:

- The FAA API applies rate limiting on a rolling basis, meaning the limit (30 requests per minute) is not strictly measured from the time we send our first request.
- Instead, the API likely tracks requests based on its own internal clock, so you might sometimes be able to make more than 30 requests before hitting the limit.