### PR TITLE
[CAP-47] Add GitHub Action to run unittests on PRs

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,33 @@
+name: Run Pytest on PRs
+
+on:
+  pull_request:
+    branches:
+      - main
+  
+  push:
+    branches:
+      - CAP-47
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: |
+          pytest
+


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that automatically runs our Python `unittest` test suite on every pull request to `main`.

## Details
- New workflow file: `.github/workflows/python-tests.yml`
- Runs tests from both `test/` and `tests/` directories
- Uses `actions/checkout@v3` and `setup-python@v4`
- Python version: 3.10
