### PR TITLE
[CAP-60] Adds support to NotamPrinter to print all details, or max lines of NOTAM text

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -8,6 +8,7 @@ from flight_path.flight_path import FlightPath
 from notam_fetcher import NotamFetcher
 from notam_fetcher.api_schema import CoreNOTAMData, Notam
 from notam_fetcher.exceptions import NotamFetcherRequestError, NotamFetcherUnauthenticatedError
+from notam_printer.notam_printer import NotamPrinter
 
 log_format_string = '%(asctime)s [%(name)s] [%(levelname)s] %(message)s'
 log_formatter = logging.Formatter(log_format_string)
@@ -23,14 +24,6 @@ logging.getLogger().addHandler(log_file_handler)
 logging.getLogger('urllib3.connectionpool').setLevel(logging.INFO)
 
 logger = logging.getLogger("driver")
-
-class NotamPrinter:
-    """
-    Temporary NotamPrinter Stub
-    """
-    def print_notams(self, notams: list[Notam]):
-        for notam in notams:
-            print(notam.text)
 
 class NotamSorter:
     """
@@ -112,7 +105,7 @@ def main():
     sorter = NotamSorter(notams)
 
     sorted_notams = sorter.sort()
-    printer = NotamPrinter()
+    printer = NotamPrinter(max_lines=3)
     printer.print_notams(sorted_notams)
 
 if __name__ == "__main__":

--- a/notam_printer/notam_printer.py
+++ b/notam_printer/notam_printer.py
@@ -57,7 +57,34 @@ class Notam:
         self.icao_location = icao_location
 
 class NotamPrinter:
-    def formatNotam(self, notam: Notam) -> str:
+
+    max_lines = None
+    print_all_fields = False
+
+    def __init__(self, max_lines: None|int=None, print_all_fields=False):
+        if max_lines is not None and int(max_lines) <= 0:
+            raise ValueError("max_lines must be a postive, non-zero integer")
+        self.max_lines = max_lines
+        self.print_all_fields = print_all_fields
+
+    def print_notam(self, notam: Notam) -> str:
+        if self.print_all_fields:
+            return self.print_all_notam_fields(notam)
+        elif self.max_lines:
+            return self.print_notam_text(notam, self.max_lines)
+        else:
+            return self.print_notam_text(notam)
+
+    def print_notam_text(self, notam: Notam, max_lines: None|int =None) -> str:
+        if max_lines:
+            return '\n'.join(notam.text.split('\n')[:max_lines]) + ('\n...' if len(notam.text.split('\n')) > max_lines else "" )
+        else:
+            return notam.text
+
+    def print_separator(self):
+        return "-"*80
+
+    def print_all_notam_fields(self, notam: Notam) -> str:
         """
         Formats a Notam object into a legible string representation.
 
@@ -83,8 +110,7 @@ class NotamPrinter:
             f"Account ID: {notam.account_id}\n"
             f"Last Updated: {notam.last_updated}\n"
             f"ICAO Location: {notam.icao_location}\n"
-            f"Text: {notam.text}\n"
-            f"{'-' * 40}"
+            f"Text: {notam.text}"
         )
 
     def print_notams(self, notams: List[Notam]):
@@ -98,8 +124,6 @@ class NotamPrinter:
 
         console = Console()
         for notam in notams:
-            console.print(self.formatNotam(notam))
-            console.print()
-            console.print("-" * 80)
-            console.print()
-            
+            console.print(self.print_notam(notam))
+            console.print(self.print_separator())
+


### PR DESCRIPTION
By default, NotamPrinter will only print the text of the NOTAM.

Limit this output to N lines by initializing NotamPrinter with `max_lines=N`, e.g. `NotamPrinter(max_line=N)`.

Restore previous behavior by print every field of the NOTAM by initializing NotamPrinter like so `NotamPrinter(print_all_fields=True)`