### PR TITLE
Cap 67 - Add basic timeout/exponential backoff to NotamFetcher

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -70,7 +70,7 @@ def main():
     flight_path = FlightPath(departure_airport, destination_airport)
     
     waypoints = flight_path.get_waypoints_by_gap(40)
-    notam_fetcher = NotamFetcher(CLIENT_ID, CLIENT_SECRET)
+    notam_fetcher = NotamFetcher(CLIENT_ID, CLIENT_SECRET, timeout=300)
     
     all_notams : list[CoreNOTAMData] = []
     start_time = time.perf_counter()

--- a/notam_fetcher/__init__.py
+++ b/notam_fetcher/__init__.py
@@ -1,5 +1,5 @@
 from .notam_fetcher import NotamFetcher
-from .exceptions import NotamFetcherRequestError, NotamFetcherUnauthenticatedError, NotamFetcherUnexpectedError, NotamFetcherBaseError, NotamFetcherValidationError
+from .exceptions import NotamFetcherTimeoutReached, NotamFetcherRequestError, NotamFetcherUnauthenticatedError, NotamFetcherUnexpectedError, NotamFetcherBaseError, NotamFetcherValidationError
 
 
-__all__ = ["NotamFetcher", "NotamFetcherRequestError", "NotamFetcherUnauthenticatedError", "NotamFetcherUnexpectedError", "NotamFetcherBaseError", "NotamFetcherValidationError"]
+__all__ = ["NotamFetcher", "NotamFetcherTimeoutReached", "NotamFetcherRequestError", "NotamFetcherUnauthenticatedError", "NotamFetcherUnexpectedError", "NotamFetcherBaseError", "NotamFetcherValidationError"]

--- a/notam_fetcher/exceptions.py
+++ b/notam_fetcher/exceptions.py
@@ -9,7 +9,7 @@ class NotamFetcherRequestError(NotamFetcherBaseError):
     """Raised when NotamFetcher receives a request exception while fetching from the API"""
 
 class NotamFetcherUnauthenticatedError(NotamFetcherBaseError):
-    """Raised when cliend_id or client_secret are invalid"""
+    """Raised when client_id or client_secret are invalid"""
 
 
 class NotamFetcherValidationError(NotamFetcherBaseError):
@@ -25,3 +25,6 @@ class NotamFetcherRateLimitError(NotamFetcherBaseError):
 
     def __init__(self):
         message = "Rate limit exceeded. Try again later."
+
+class NotamFetcherTimeoutReached(NotamFetcherBaseError):
+    """Raised when NotamFetcher is terminated early because it exceeded the timeout."""


### PR DESCRIPTION
Previously we had issues with long flight paths
OKC → SYA rate-limited (108 waypoints)
KOKC → KBOS rate-limited (39 requests)

In this PR we are adding exponential backoff so that NotamFetcher can complete these long flight paths even if it extends past our desired 60s.